### PR TITLE
TEAMNADO-2098 - Change URL for Satellite Manifest component

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -15,7 +15,7 @@ export const Routes: ReactNode = () => (
     }
   >
     <Switch>
-      <Route path="/" component={SatelliteManifestPage} />
+      <Route exact path="/" component={SatelliteManifestPage} />
       <Route path="/oops" component={OopsPage} />
       <Route path="/no-permissions" component={NoPermissionsPage} />
       {/* Finally, catch all unmatched routes */}

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -15,7 +15,7 @@ export const Routes: ReactNode = () => (
     }
   >
     <Switch>
-      <Route path="/satellite-manifest" component={SatelliteManifestPage} />
+      <Route path="/" component={SatelliteManifestPage} />
       <Route path="/oops" component={OopsPage} />
       <Route path="/no-permissions" component={NoPermissionsPage} />
       {/* Finally, catch all unmatched routes */}


### PR DESCRIPTION
The cloud-services-config file specifies where our app will show up, under /insights/subscriptions/manifests.  That part has been updated in a separate PR in the [cloud-services-config repo](https://github.com/RedHatInsights/cloud-services-config).

Since the ultimate URL we want for this is /insights/subscriptions/manifests (which will be switched to /rhel/subscriptions/manifests post-Summit), we need to change the route for the Satellite Manifest page to render at the application root, which is what this PR changes.