### PR TITLE
TEAMNADO-2098 updating app name to manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ SPANDX_CONFIG="./profiles/local-frontend.js" bash $PROXY_PATH/scripts/run.sh
 
 4. Open one of the following environments behind the Red Hat VPN and accept the certs:
 
-- https://ci.foo.redhat.com:1337/beta/insights/subscription-central
-- https://qa.foo.redhat.com:1337/beta/insights/subscription-central
-- https://stage.foo.redhat.com:1337/beta/insights/subscription-central
-- https://prod.foo.redhat.com:1337/beta/insights/subscription-central
+- https://ci.foo.redhat.com:1337/beta/insights/subscriptions/manifests
+- https://qa.foo.redhat.com:1337/beta/insights/subscriptions/manifests
+- https://stage.foo.redhat.com:1337/beta/insights/subscriptions/manifests
+- https://prod.foo.redhat.com:1337/beta/insights/subscriptions/manifests
 
 For convenience, the script to run the front-end and the proxy has been provided as `npm run start:proxy`, provided that the insights-proxy repo is located in the parent folder, and Docker is running.
 

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -6,14 +6,14 @@ const { config: webpackConfig, plugins } = config({
   debug: true,
   https: true,
   useFileHash: false,
-  modules: ['subscriptionCentral'],
+  modules: ['manifests'],
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
 plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')({
     root: resolve(__dirname, '../'),
-    moduleName: 'subscriptionCentral',
+    moduleName: 'manifests',
     useFileHash: false
   })
 );

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -5,14 +5,14 @@ const config = require('@redhat-cloud-services/frontend-components-config');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
-  modules: ['subscriptionCentral'],
+  modules: ['manifests'],
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
 plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')({
     root: resolve(__dirname, '../'),
-    moduleName: 'subscriptionCentral'
+    moduleName: 'manifests'
   })
 );
 

--- a/package.json
+++ b/package.json
@@ -131,6 +131,6 @@
     "webpack-cli": "4.5.0"
   },
   "insights": {
-    "appname": "subscription-central"
+    "appname": "manifests"
   }
 }

--- a/profiles/local-frontend-and-api.js
+++ b/profiles/local-frontend-and-api.js
@@ -1,5 +1,5 @@
 const SECTION = 'insights';
-const APP_ID = 'subscription-central';
+const APP_ID = 'manifests';
 const FRONTEND_PORT = 8002;
 const API_PORT = 8888;
 const routes = {};

--- a/profiles/local-frontend.js
+++ b/profiles/local-frontend.js
@@ -1,12 +1,12 @@
 const SECTION = 'insights';
-const APP_ID = 'subscription-central';
+const APP_ID = 'manifests';
 const FRONTEND_PORT = 8002;
 const routes = {};
 
 routes[`/beta/${SECTION}/subscriptions`] = {
   host: `https://localhost:${FRONTEND_PORT}`
 };
-routes[`/${SECTION}/${APP_ID}`] = {
+routes[`/${SECTION}/subscriptions/${APP_ID}`] = {
   host: `https://localhost:${FRONTEND_PORT}`
 };
 routes[`/beta/apps/${APP_ID}`] = { host: `https://localhost:${FRONTEND_PORT}` };

--- a/src/App.js
+++ b/src/App.js
@@ -26,7 +26,7 @@ const App = (props) => {
     registry.register({ notifications: notificationsReducer });
     insights.chrome.init();
 
-    insights.chrome.identifyApp('subscription-central');
+    insights.chrome.identifyApp('manifests');
     return insights.chrome.on('APP_NAVIGATION', (event) =>
       this.props.history.push(`/${event.navId}`)
     );


### PR DESCRIPTION
This updates the app-name from subscription-central to manifests, to align with the config updates.  This will allow for proper functionality of the side menu for the /insights/subscriptions/manifests route on cloud.redhat.com environments, so that the chrome menu app can identify we are on the manifests page and render properly.

Note that the app now also renders, when running locally, at /insights/subscriptions/manifests