### PR TITLE
Fix scss compilation

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -6,8 +6,8 @@ const { config: webpackConfig, plugins } = config({
   debug: true,
   https: true,
   useFileHash: false,
-  ...(process.env.BETA && { deployment: 'beta/apps', sassPrefix: '.subscriptions' }),
-  modules: ['manifests']
+  modules: ['manifests'],
+  ...(process.env.BETA && { deployment: 'beta/apps', sassPrefix: '.subscriptions' })
 });
 
 plugins.push(

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -6,6 +6,7 @@ const { config: webpackConfig, plugins } = config({
   debug: true,
   https: true,
   useFileHash: false,
+  sassPrefix: '.subscriptions',
   modules: ['manifests'],
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -6,9 +6,8 @@ const { config: webpackConfig, plugins } = config({
   debug: true,
   https: true,
   useFileHash: false,
-  sassPrefix: '.subscriptions',
-  modules: ['manifests'],
-  ...(process.env.BETA && { deployment: 'beta/apps' })
+  ...(process.env.BETA && { deployment: 'beta/apps', sassPrefix: '.subscriptions' }),
+  modules: ['manifests']
 });
 
 plugins.push(

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -5,6 +5,7 @@ const config = require('@redhat-cloud-services/frontend-components-config');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
+  sassPrefix: '.subscriptions',
   modules: ['manifests'],
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -5,8 +5,8 @@ const config = require('@redhat-cloud-services/frontend-components-config');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
-  ...(process.env.BETA && { deployment: 'beta/apps', sassPrefix: '.subscriptions' }),
-  modules: ['manifests']
+  modules: ['manifests'],
+  ...(process.env.BETA && { deployment: 'beta/apps', sassPrefix: '.subscriptions' })
 });
 
 plugins.push(

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -5,9 +5,8 @@ const config = require('@redhat-cloud-services/frontend-components-config');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
-  sassPrefix: '.subscriptions',
-  modules: ['manifests'],
-  ...(process.env.BETA && { deployment: 'beta/apps' })
+  ...(process.env.BETA && { deployment: 'beta/apps', sassPrefix: '.subscriptions' }),
+  modules: ['manifests']
 });
 
 plugins.push(

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
     "start:beta": "BETA=true NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
     "start:proxy": "run-p proxy start",
+    "start-beta:proxy": "run-p proxy start:beta",
     "test": "jest --verbose",
     "test:watch": "jest --watch",
     "verify": "npm-run-all build lint test"


### PR DESCRIPTION
insights-chrome (the parent app) adds a class name to the main, based on the "app ID" which in this case, because we are added on top of subscription watch, is 'subscriptions'.  So it creates a `<main class="subscriptions">...</main>`.

Our app, when compiling scss down to css, is adding a root class of `manifests` to "namespace" the app's css. So all scss will get rendered as, e.g., `.manifests h2 { color: #000 }`.    We currently do not have a div with a class of manifests anywhere.  So when this is getting pushed to CI etc., our custom CSS is not being applied.

This fix uses the sassPrefix option provided in [frontend-components-config](https://github.com/RedHatInsights/frontend-components/tree/master/packages/config#readme) to set the sassPrefix  to be `.subscriptions` so that the CSS applies correctly (e.g., now the above will compile to `.subscriptions h2 { color: #000 }`).

This also adds a `start-beta:proxy` script to run the app in beta mode with the proxy server.