### PR TITLE
Fix bug where clicking popover icon triggers table re-sort

### DIFF
--- a/src/components/SCAInfoIconWithPopover/SCAInfoIconWithPopover.tsx
+++ b/src/components/SCAInfoIconWithPopover/SCAInfoIconWithPopover.tsx
@@ -29,7 +29,12 @@ const SCAInfoIconWithPopover: FunctionComponent = () => {
           </ExternalLink>
         }
       >
-        <InfoIcon className="sca-more-info-icon" />
+        <InfoIcon
+          className="sca-more-info-icon"
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+        />
       </Popover>
     </>
   );


### PR DESCRIPTION
Currently, when clicking the Simple Content Access info icon, it triggers a resort.  This adds a fix to prevent the resort.  

![Screenshot from 2021-04-09 12-25-18](https://user-images.githubusercontent.com/4838984/114211585-d1108c00-992e-11eb-8f3e-094a9602cb1a.png)
