### PR TITLE
Fix app CSS

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -7,7 +7,7 @@ const { config: webpackConfig, plugins } = config({
   https: true,
   useFileHash: false,
   modules: ['manifests'],
-  ...(process.env.BETA && { deployment: 'beta/apps', sassPrefix: '.subscriptions' })
+  ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
 plugins.push(

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -6,7 +6,7 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   modules: ['manifests'],
-  ...(process.env.BETA && { deployment: 'beta/apps', sassPrefix: '.subscriptions' })
+  ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
 plugins.push(

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -7,21 +7,23 @@ const OopsPage = lazy(() => import('./pages/OopsPage'));
 const NoPermissionsPage = lazy(() => import('./pages/NoPermissionsPage'));
 
 export const Routes: ReactNode = () => (
-  <Suspense
-    fallback={
-      <Bullseye>
-        <Spinner />
-      </Bullseye>
-    }
-  >
-    <Switch>
-      <Route exact path="/" component={SatelliteManifestPage} />
-      <Route path="/oops" component={OopsPage} />
-      <Route path="/no-permissions" component={NoPermissionsPage} />
-      {/* Finally, catch all unmatched routes */}
-      <Route>
-        <Redirect to="/oops" />
-      </Route>
-    </Switch>
-  </Suspense>
+  <div className="manifests">
+    <Suspense
+      fallback={
+        <Bullseye>
+          <Spinner />
+        </Bullseye>
+      }
+    >
+      <Switch>
+        <Route exact path="/" component={SatelliteManifestPage} />
+        <Route path="/oops" component={OopsPage} />
+        <Route path="/no-permissions" component={NoPermissionsPage} />
+        {/* Finally, catch all unmatched routes */}
+        <Route>
+          <Redirect to="/oops" />
+        </Route>
+      </Switch>
+    </Suspense>
+  </div>
 );


### PR DESCRIPTION
Per conversations with c.rh.c team, the class name of the main component is diverging between beta and stable branches, because the Chrome 2.0 changes have not been deployed to stable environments.  As a result, the CSS is not applying correctly on beta branches.  

This removes a previous sassPrefix fix and wraps the application in a `<div className="manifests"></div>` so that the CSS applies correctly across environments.

We should be able to remove this prefix after Summit, by which point the diverging class names between environments should be resolved. 