### PR TITLE
Removing the search bar when no manifests are returned and user is not org admin

### DIFF
--- a/src/components/SatelliteManifestPanel/SatelliteManifestPanel.tsx
+++ b/src/components/SatelliteManifestPanel/SatelliteManifestPanel.tsx
@@ -157,14 +157,16 @@ const SatelliteManifestPanel: FunctionComponent<SatelliteManifestPanelProps> = (
       >
         <FlexItem>
           <Split hasGutter>
-            <SplitItem isFilled>
-              <SearchInput
-                placeholder="Filter by name, version or UUID"
-                value={searchValue}
-                onChange={handleSearch}
-                onClear={clearSearch}
-              />
-            </SplitItem>
+            {data.length > 0 && (
+              <SplitItem isFilled>
+                <SearchInput
+                  placeholder="Filter by name, version or UUID"
+                  value={searchValue}
+                  onChange={handleSearch}
+                  onClear={clearSearch}
+                />
+              </SplitItem>
+            )}
             {user.isOrgAdmin === true && (
               <SplitItem>
                 <CreateManifestButtonWithModal />

--- a/src/components/SatelliteManifestPanel/__tests__/__snapshots__/SatelliteManifestPanel.test.tsx.snap
+++ b/src/components/SatelliteManifestPanel/__tests__/__snapshots__/SatelliteManifestPanel.test.tsx.snap
@@ -763,50 +763,6 @@ exports[`Satellite Manifest Panel renders loading when refetching data 1`] = `
           class="pf-l-split pf-m-gutter"
         >
           <div
-            class="pf-l-split__item pf-m-fill"
-          >
-            <div
-              class="pf-c-search-input"
-            >
-              <div
-                class="pf-c-input-group"
-              >
-                <div
-                  class="pf-c-search-input__bar"
-                >
-                  <span
-                    class="pf-c-search-input__text"
-                  >
-                    <span
-                      class="pf-c-search-input__icon"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 512 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                        />
-                      </svg>
-                    </span>
-                    <input
-                      aria-label="Search input"
-                      class="pf-c-search-input__text-input"
-                      placeholder="Filter by name, version or UUID"
-                      value=""
-                    />
-                  </span>
-                  
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
             class="pf-l-split__item"
           >
             <button
@@ -1492,50 +1448,6 @@ exports[`Satellite Manifest Panel renders no results when there are no results 1
         <div
           class="pf-l-split pf-m-gutter"
         >
-          <div
-            class="pf-l-split__item pf-m-fill"
-          >
-            <div
-              class="pf-c-search-input"
-            >
-              <div
-                class="pf-c-input-group"
-              >
-                <div
-                  class="pf-c-search-input__bar"
-                >
-                  <span
-                    class="pf-c-search-input__text"
-                  >
-                    <span
-                      class="pf-c-search-input__icon"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 512 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                        />
-                      </svg>
-                    </span>
-                    <input
-                      aria-label="Search input"
-                      class="pf-c-search-input__text-input"
-                      placeholder="Filter by name, version or UUID"
-                      value=""
-                    />
-                  </span>
-                  
-                </div>
-              </div>
-            </div>
-          </div>
           <div
             class="pf-l-split__item"
           >

--- a/src/pages/SatelliteManifestPage/__tests__/__snapshots__/SatelliteManifestPage.test.tsx.snap
+++ b/src/pages/SatelliteManifestPage/__tests__/__snapshots__/SatelliteManifestPage.test.tsx.snap
@@ -899,52 +899,7 @@ exports[`Satellite Manifests Page renders the empty table with no manifests foun
         >
           <div
             class="pf-l-split pf-m-gutter"
-          >
-            <div
-              class="pf-l-split__item pf-m-fill"
-            >
-              <div
-                class="pf-c-search-input"
-              >
-                <div
-                  class="pf-c-input-group"
-                >
-                  <div
-                    class="pf-c-search-input__bar"
-                  >
-                    <span
-                      class="pf-c-search-input__text"
-                    >
-                      <span
-                        class="pf-c-search-input__icon"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style="vertical-align: -0.125em;"
-                          viewBox="0 0 512 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                          />
-                        </svg>
-                      </span>
-                      <input
-                        aria-label="Search input"
-                        class="pf-c-search-input__text-input"
-                        placeholder="Filter by name, version or UUID"
-                        value=""
-                      />
-                    </span>
-                    
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          />
         </div>
         <div
           class="pf-m-align-right"


### PR DESCRIPTION
During demo, Jon Allen recommended that we remove the search bar when is_org_admin is false, and no manifests are found.  

### Changes
- Updates SatelliteManifestPanel to hide the search bar when is_org_admin is false and no manifests are found.  
- Updates related tests.

![Screenshot from 2021-04-22 13-34-02](https://user-images.githubusercontent.com/4838984/115708396-396c5e00-a370-11eb-8b08-289f058b3fa9.png)
