### PR TITLE
Env-specific config setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+API_HOST=https://api.access.redhat.com

--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-API_HOST=https://api.access.redhat.com
+API_HOST=https://api.access.qa.redhat.com

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+API_HOST=https://api.access.qa.redhat.com

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,0 @@
-API_HOST=https://api.access.qa.redhat.com

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+API_HOST=https://api.access.redhat.com

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -11,7 +11,7 @@ const { config: webpackConfig, plugins } = config({
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
-const dotEnvParams = {
+let dotEnvParams = {
   defaults: resolve(__dirname, '../.env')
 };
 

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -13,7 +13,7 @@ const { config: webpackConfig, plugins } = config({
 
 const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env';
 const envPath = resolve(__dirname, `../${envFileName}`);
-plugins.push(new Dotenv({ path: envPath }));
+plugins.push(new Dotenv({ path: envPath, defaults: resolve(__dirname, '../.env') }));
 
 plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')({

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -11,7 +11,7 @@ const { config: webpackConfig, plugins } = config({
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
-const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env.development';
+const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env';
 const envPath = resolve(__dirname, `../${envFileName}`);
 plugins.push(new Dotenv({ path: envPath, defaults: resolve(__dirname, '../.env') }));
 

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
+const Dotenv = require('dotenv-webpack');
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   debug: true,
@@ -9,6 +10,10 @@ const { config: webpackConfig, plugins } = config({
   modules: ['manifests'],
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
+
+const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env';
+const envPath = resolve(__dirname, `../${envFileName}`);
+plugins.push(new Dotenv({ path: envPath }));
 
 plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')({

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -11,7 +11,11 @@ const { config: webpackConfig, plugins } = config({
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
-const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env';
+let envFileName = '.env';
+if (process.env.NODE_ENV && process.env.NODE_ENV !== 'development') {
+  envFileName = `.env.${process.env.NODE_ENV}`;
+}
+
 const envPath = resolve(__dirname, `../${envFileName}`);
 plugins.push(new Dotenv({ path: envPath, defaults: resolve(__dirname, '../.env') }));
 

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -11,13 +11,15 @@ const { config: webpackConfig, plugins } = config({
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
-let envFileName = '.env';
+const dotEnvParams = {
+  defaults: resolve(__dirname, '../.env')
+};
+
 if (process.env.NODE_ENV && process.env.NODE_ENV !== 'development') {
-  envFileName = `.env.${process.env.NODE_ENV}`;
+  dotEnvParams.path = resolve(__dirname, `../.env.${process.env.NODE_ENV}`);
 }
 
-const envPath = resolve(__dirname, `../${envFileName}`);
-plugins.push(new Dotenv({ path: envPath, defaults: resolve(__dirname, '../.env') }));
+plugins.push(new Dotenv({ ...dotEnvParams }));
 
 plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')({

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -11,7 +11,7 @@ const { config: webpackConfig, plugins } = config({
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
-const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env';
+const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env.development';
 const envPath = resolve(__dirname, `../${envFileName}`);
 plugins.push(new Dotenv({ path: envPath, defaults: resolve(__dirname, '../.env') }));
 

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -12,7 +12,7 @@ const { config: webpackConfig, plugins } = config({
 
 const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env';
 const envPath = resolve(__dirname, `../${envFileName}`);
-plugins.push(new Dotenv({ path: envPath }));
+plugins.push(new Dotenv({ path: envPath, defaults: resolve(__dirname, '../.env') }));
 
 plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')({

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -10,7 +10,11 @@ const { config: webpackConfig, plugins } = config({
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
-const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env';
+let envFileName = '.env';
+if (process.env.NODE_ENV && process.env.NODE_ENV !== 'development') {
+  envFileName = `.env.${process.env.NODE_ENV}`;
+}
+
 const envPath = resolve(__dirname, `../${envFileName}`);
 plugins.push(new Dotenv({ path: envPath, defaults: resolve(__dirname, '../.env') }));
 

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -3,11 +3,16 @@
 const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const Dotenv = require('dotenv-webpack');
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   modules: ['manifests'],
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
+
+const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env';
+const envPath = resolve(__dirname, `../${envFileName}`);
+plugins.push(new Dotenv({ path: envPath }));
 
 plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')({

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -10,7 +10,7 @@ const { config: webpackConfig, plugins } = config({
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
-const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env.development';
+const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env';
 const envPath = resolve(__dirname, `../${envFileName}`);
 plugins.push(new Dotenv({ path: envPath, defaults: resolve(__dirname, '../.env') }));
 

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -10,7 +10,7 @@ const { config: webpackConfig, plugins } = config({
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
-const dotEnvParams = {
+let dotEnvParams = {
   defaults: resolve(__dirname, '../.env')
 };
 

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -10,13 +10,15 @@ const { config: webpackConfig, plugins } = config({
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
-let envFileName = '.env';
+const dotEnvParams = {
+  defaults: resolve(__dirname, '../.env')
+};
+
 if (process.env.NODE_ENV && process.env.NODE_ENV !== 'development') {
-  envFileName = `.env.${process.env.NODE_ENV}`;
+  dotEnvParams.path = resolve(__dirname, `../.env.${process.env.NODE_ENV}`);
 }
 
-const envPath = resolve(__dirname, `../${envFileName}`);
-plugins.push(new Dotenv({ path: envPath, defaults: resolve(__dirname, '../.env') }));
+plugins.push(new Dotenv({ ...dotEnvParams }));
 
 plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')({

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -10,7 +10,7 @@ const { config: webpackConfig, plugins } = config({
   ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
-const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env';
+const envFileName = process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env.development';
 const envPath = resolve(__dirname, `../${envFileName}`);
 plugins.push(new Dotenv({ path: envPath, defaults: resolve(__dirname, '../.env') }));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5151,6 +5151,30 @@
         }
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
+    "dotenv-defaults": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.1.tgz",
+      "integrity": "sha512-ugFCyBF7ILuwpmznduHPQZBMucHHJ8T4OBManTEVjemxCm2+nqifSuW2lD2SNKdiKSH1E324kZSdJ8M04b4I/A==",
+      "dev": true,
+      "requires": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "dotenv-webpack": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-7.0.2.tgz",
+      "integrity": "sha512-RY+/5uM/XY4bGtih9f9ic8hlrUDxVcZZBPWlnX/aHhaKxcVVX9SH/5VH7CSmvVo9GL6PKvQOA0X1bc552rnatQ==",
+      "dev": true,
+      "requires": {
+        "dotenv-defaults": "^2.0.1"
+      }
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "babel-plugin-transform-imports": "^2.0.0",
     "cross-fetch": "3.0.4",
     "css-loader": "5.0.1",
+    "dotenv-webpack": "^7.0.2",
     "eslint": "7.19.0",
     "eslint-config-prettier": "6.11.0",
     "eslint-loader": "4.0.2",

--- a/src/hooks/useCreateSatelliteManifest.ts
+++ b/src/hooks/useCreateSatelliteManifest.ts
@@ -10,7 +10,7 @@ const createSatelliteManifest = (data: CreateManifestParams) => {
   const { name, version } = data;
   const jwtToken = Cookies.get('cs_jwt');
   return fetch(
-    `https://api.access.qa.redhat.com/management/v1/allocations?name=${name}&version=${version}`,
+    `${process.env.API_HOST}/management/v1/allocations?name=${name}&version=${version}`,
     {
       method: 'POST',
       headers: { Authorization: `Bearer ${jwtToken}` }

--- a/src/hooks/useSatelliteManifests.ts
+++ b/src/hooks/useSatelliteManifests.ts
@@ -22,7 +22,7 @@ interface SatelliteManifestAPIData {
 
 const fetchSatelliteManifestData = (): Promise<any> => {
   const jwtToken = Cookies.get('cs_jwt');
-  return fetch('https://api.access.qa.redhat.com/management/v1/allocations', {
+  return fetch(`${process.env.API_HOST}/management/v1/allocations`, {
     headers: { Authorization: `Bearer ${jwtToken}` },
     mode: 'cors'
   })

--- a/src/hooks/useSatelliteVersions.ts
+++ b/src/hooks/useSatelliteVersions.ts
@@ -8,7 +8,7 @@ interface SatelliteVersion {
 
 const fetchSatelliteVersions = (): Promise<any> => {
   const jwtToken = Cookies.get('cs_jwt');
-  return fetch('https://api.access.qa.redhat.com/management/v1/allocations/versions', {
+  return fetch(`${process.env.API_HOST}/management/v1/allocations/versions`, {
     headers: { Authorization: `Bearer ${jwtToken}` },
     mode: 'cors'
   })


### PR DESCRIPTION
Changes: 

- Uses the [dotenv-webpack](https://github.com/mrsteele/dotenv-webpack) module to have environment-specific env files.
- Updates the API base to be pulled in from the respective .env file.

This is shown as an alternative solution to https://github.com/RedHatInsights/subscription-central-ui/pull/15 

Note that from my understanding, the actual NODE_ENV value that determines which .env file to use is being set in the npm scripts, and that currently there is only a development and a production mode.  

If we want a staging mode, we would have to adjust the scripts and probably work with the cloud dot team to update the deployment setup.  I think for now this is fine, since the stage environment is pretty neglected and it seems we will probably also be bypassing it.