### PR TITLE
replacing contentAccessMode with simpleContentAccess throughout App

### DIFF
--- a/src/components/ManifestDetailSidePanel/ManifestDetailSidePanel.tsx
+++ b/src/components/ManifestDetailSidePanel/ManifestDetailSidePanel.tsx
@@ -63,7 +63,7 @@ const ManifestDetailSidePanel: FC<ManifestDetailSidePanelProps> = ({
       createdBy,
       lastModified,
       entitlementsAttachedQuantity,
-      contentAccessMode
+      simpleContentAccess
     } = data.body;
 
     const formatDate = (dateString: string) => {
@@ -106,7 +106,7 @@ const ManifestDetailSidePanel: FC<ManifestDetailSidePanelProps> = ({
               <SCAInfoIconWithPopover />
             </strong>
           </GridItem>
-          <GridItem span={6}>{contentAccessMode}</GridItem>
+          <GridItem span={6}>{simpleContentAccess}</GridItem>
 
           <GridItem span={6}>
             <strong>Quantity</strong>

--- a/src/components/ManifestDetailSidePanel/__tests__/ManifestDetailSidePanel.test.tsx
+++ b/src/components/ManifestDetailSidePanel/__tests__/ManifestDetailSidePanel.test.tsx
@@ -59,7 +59,7 @@ describe('Manifest Detail Side Panel', () => {
           createdBy: 'Jane Doe',
           lastModified: '2021-01-01T00:00:00.000Z',
           entitlementsAttachedQuantity: 10,
-          contentAccessMode: 'Enabled'
+          simpleContentAccess: 'enabled'
         }
       }
     }));

--- a/src/components/ManifestDetailSidePanel/__tests__/__snapshots__/ManifestDetailSidePanel.test.tsx.snap
+++ b/src/components/ManifestDetailSidePanel/__tests__/__snapshots__/ManifestDetailSidePanel.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`Manifest Detail Side Panel renders successfully with data when data is 
             <div
               class="pf-l-grid__item pf-m-6-col"
             >
-              Enabled
+              enabled
             </div>
             <div
               class="pf-l-grid__item pf-m-6-col"

--- a/src/components/SatelliteManifestPanel/__tests__/SatelliteManifestPanel.test.tsx
+++ b/src/components/SatelliteManifestPanel/__tests__/SatelliteManifestPanel.test.tsx
@@ -22,7 +22,8 @@ describe('Satellite Manifest Panel', () => {
         url: 'www.example.com',
         uuid: '00000000-0000-0000-0000-000000000000',
         version: '1.2.3',
-        entitlementQuantity: 5
+        entitlementQuantity: 5,
+        simpleContentAccess: 'enabled'
       }
     ];
 

--- a/src/components/SatelliteManifestPanel/__tests__/__snapshots__/SatelliteManifestPanel.test.tsx.snap
+++ b/src/components/SatelliteManifestPanel/__tests__/__snapshots__/SatelliteManifestPanel.test.tsx.snap
@@ -588,7 +588,9 @@ exports[`Satellite Manifest Panel renders correctly 1`] = `
                     class=""
                     data-key="3"
                     data-label="column-3"
-                  />
+                  >
+                    enabled
+                  </td>
                   <td
                     class=""
                     data-key="4"

--- a/src/hooks/__tests__/useManifestEntitlements.test.tsx
+++ b/src/hooks/__tests__/useManifestEntitlements.test.tsx
@@ -43,7 +43,7 @@ describe('useManifestEntitlements hook', () => {
           }
         ]
       },
-      contentAccessMode: 'Entitlement Access'
+      simpleContentAccess: 'enabled'
     };
 
     fetch.mockResponseOnce(JSON.stringify(mockResponse));

--- a/src/hooks/useManifestEntitlements.ts
+++ b/src/hooks/useManifestEntitlements.ts
@@ -14,7 +14,7 @@ interface ManifestEntitlement {
 
 interface ManifestEntitlementsData {
   body: {
-    contentAccessMode: string;
+    simpleContentAccess: string;
     createdBy: string;
     createdDate: string;
     entitlementsAttached: EntitlementsAttachedData;

--- a/src/hooks/useSatelliteManifests.ts
+++ b/src/hooks/useSatelliteManifests.ts
@@ -9,7 +9,7 @@ interface ManifestEntry {
   url: string;
   uuid: string;
   version: string;
-  simpleContentAccess?: string;
+  simpleContentAccess: string;
 }
 
 interface SatelliteManifestAPIData {


### PR DESCRIPTION
Per recent API changes done in [TEAMNADO-2140](https://issues.redhat.com/browse/TEAMNADO-2140), this updates the app to replace the property `contentAccessMode` with `simpleContentAccess`.