### PR TITLE
Fix delete notification for last manifest

### DIFF
--- a/src/components/SatelliteManifestPanel/SatelliteManifestPanel.tsx
+++ b/src/components/SatelliteManifestPanel/SatelliteManifestPanel.tsx
@@ -25,6 +25,7 @@ import {
   expandable
 } from '@patternfly/react-table';
 import { User } from '../../hooks/useUser';
+import { CreateManifestPanel } from '../../components/emptyState';
 import SCAInfoIconWithPopover from '../SCAInfoIconWithPopover';
 import { ManifestEntry } from '../../hooks/useSatelliteManifests';
 import { NoSearchResults } from '../emptyState';
@@ -379,66 +380,71 @@ const SatelliteManifestPanel: FunctionComponent<SatelliteManifestPanelProps> = (
   };
 
   return (
-    <PageSection variant="light">
-      <Drawer isExpanded={detailsDrawerIsExpanded}>
-        <DrawerContent panelContent={panelContent}>
-          <DrawerContentBody>
-            <Title headingLevel="h2">
-              <span ref={titleRef}>Manifests</span>
-              {!isFetching && <Badge isRead>{count()}</Badge>}
-            </Title>
-            <Flex
-              direction={{ default: 'column', md: 'row' }}
-              justifyContent={{ default: 'justifyContentSpaceBetween' }}
-            >
-              <FlexItem>
-                <Split hasGutter>
-                  {data.length > 0 && (
-                    <SplitItem isFilled>
-                      <SearchInput
-                        placeholder="Filter by name, version or UUID"
-                        value={searchValue}
-                        onChange={handleSearch}
-                        onClear={clearSearch}
-                      />
-                    </SplitItem>
-                  )}
-                  {user.isOrgAdmin === true && (
-                    <SplitItem>
-                      <CreateManifestButtonWithModal />
-                    </SplitItem>
-                  )}
-                </Split>
-              </FlexItem>
-              <FlexItem align={{ default: 'alignRight' }}>{pagination()}</FlexItem>
-            </Flex>
-            <Table
-              aria-label="Satellite Manifest Table"
-              cells={getTableHeaders()}
-              rows={isFetching ? [] : getRowsWithAllocationDetails()}
-              onCollapse={toggleAllocationDetails}
-              sortBy={sortBy}
-              onSort={handleSort}
-              actions={actions()}
-            >
-              <TableHeader />
-              <TableBody />
-            </Table>
-            {count() === 0 && data.length > 0 && <NoSearchResults clearFilters={clearSearch} />}
-            {!isFetching && data.length === 0 && <NoManifestsFound />}
-            {isFetching && <Processing />}
-            {pagination(PaginationVariant.bottom)}
-            <DeleteManifestConfirmationModal
-              uuid={currentDeletionUUID}
-              name={currentDeletionName}
-              isOpen={isDeleteManifestConfirmationModalOpen}
-              handleModalToggle={handleDeleteManifestConfirmationModalToggle}
-              onSuccess={closeDetailsPanel}
-            />
-          </DrawerContentBody>
-        </DrawerContent>
-      </Drawer>
-    </PageSection>
+    <>
+      {data?.length === 0 && user.isOrgAdmin && <CreateManifestPanel />}
+      {(data?.length > 0 || !user.isOrgAdmin) && (
+        <PageSection variant="light">
+          <Drawer isExpanded={detailsDrawerIsExpanded}>
+            <DrawerContent panelContent={panelContent}>
+              <DrawerContentBody>
+                <Title headingLevel="h2">
+                  <span ref={titleRef}>Manifests</span>
+                  {!isFetching && <Badge isRead>{count()}</Badge>}
+                </Title>
+                <Flex
+                  direction={{ default: 'column', md: 'row' }}
+                  justifyContent={{ default: 'justifyContentSpaceBetween' }}
+                >
+                  <FlexItem>
+                    <Split hasGutter>
+                      {data.length > 0 && (
+                        <SplitItem isFilled>
+                          <SearchInput
+                            placeholder="Filter by name, version or UUID"
+                            value={searchValue}
+                            onChange={handleSearch}
+                            onClear={clearSearch}
+                          />
+                        </SplitItem>
+                      )}
+                      {user.isOrgAdmin === true && (
+                        <SplitItem>
+                          <CreateManifestButtonWithModal />
+                        </SplitItem>
+                      )}
+                    </Split>
+                  </FlexItem>
+                  <FlexItem align={{ default: 'alignRight' }}>{pagination()}</FlexItem>
+                </Flex>
+                <Table
+                  aria-label="Satellite Manifest Table"
+                  cells={getTableHeaders()}
+                  rows={isFetching ? [] : getRowsWithAllocationDetails()}
+                  onCollapse={toggleAllocationDetails}
+                  sortBy={sortBy}
+                  onSort={handleSort}
+                  actions={actions()}
+                >
+                  <TableHeader />
+                  <TableBody />
+                </Table>
+                {count() === 0 && data.length > 0 && <NoSearchResults clearFilters={clearSearch} />}
+                {!isFetching && data.length === 0 && <NoManifestsFound />}
+                {isFetching && <Processing />}
+                {pagination(PaginationVariant.bottom)}
+              </DrawerContentBody>
+            </DrawerContent>
+          </Drawer>
+        </PageSection>
+      )}
+      <DeleteManifestConfirmationModal
+        uuid={currentDeletionUUID}
+        name={currentDeletionName}
+        isOpen={isDeleteManifestConfirmationModalOpen}
+        handleModalToggle={handleDeleteManifestConfirmationModalToggle}
+        onSuccess={closeDetailsPanel}
+      />
+    </>
   );
 };
 

--- a/src/components/SatelliteManifestPanel/__tests__/SatelliteManifestPanel.test.tsx
+++ b/src/components/SatelliteManifestPanel/__tests__/SatelliteManifestPanel.test.tsx
@@ -72,7 +72,26 @@ describe('Satellite Manifest Panel', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('renders no results when there are no results', () => {
+  it('renders no results when there are no results and user is not admin', () => {
+    (useSatelliteVersions as jest.Mock).mockReturnValue({
+      body: [] as SatelliteVersion[]
+    });
+
+    const props = {
+      data: [] as ManifestEntry[],
+      isFetching: false,
+      user: { isOrgAdmin: false, isSCACapable: true }
+    };
+
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <SatelliteManifestPanel {...props} />
+      </QueryClientProvider>
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders a blank state  when there are no results and user is admin', () => {
     (useSatelliteVersions as jest.Mock).mockReturnValue({
       body: [] as SatelliteVersion[]
     });
@@ -96,7 +115,17 @@ describe('Satellite Manifest Panel', () => {
       body: [] as SatelliteVersion[]
     });
 
-    const data: ManifestEntry[] = [];
+    const data: ManifestEntry[] = [
+      {
+        name: 'Sputnik',
+        type: 'Satellite',
+        url: 'www.example.com',
+        uuid: '00000000-0000-0000-0000-000000000000',
+        version: '1.2.3',
+        entitlementQuantity: 5,
+        simpleContentAccess: 'enabled'
+      }
+    ];
 
     const props = {
       data,

--- a/src/components/SatelliteManifestPanel/__tests__/__snapshots__/SatelliteManifestPanel.test.tsx.snap
+++ b/src/components/SatelliteManifestPanel/__tests__/__snapshots__/SatelliteManifestPanel.test.tsx.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Satellite Manifest Panel renders a blank state  when there are no results and user is admin 1`] = `
+<div>
+  <div
+    class="pf-c-empty-state pf-m-lg"
+  >
+    <div
+      class="pf-c-empty-state__content"
+    >
+      <svg
+        aria-hidden="true"
+        class="pf-c-empty-state__icon"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 512 512"
+        width="1em"
+      >
+        <path
+          d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
+        />
+      </svg>
+      <h2
+        class="pf-c-title pf-m-lg"
+      >
+        Create a new manifest to export subscriptions
+      </h2>
+      <div
+        class="pf-c-empty-state__body"
+      >
+        You currently have no manifests displayed. Create a new manifest to export subscriptions from the Red Hat Customer Portal to your on-premise subscription management application.
+      </div>
+      <button
+        aria-disabled="false"
+        class="pf-c-button pf-m-primary"
+        data-ouia-component-id="OUIA-Generated-Button-primary-3"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        type="button"
+      >
+        Create new manifest
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Satellite Manifest Panel renders correctly with SCA column when user is SCA Capable 1`] = `
 <div>
   <section
@@ -1860,6 +1907,50 @@ exports[`Satellite Manifest Panel renders loading when refetching data 1`] = `
                   class="pf-l-split pf-m-gutter"
                 >
                   <div
+                    class="pf-l-split__item pf-m-fill"
+                  >
+                    <div
+                      class="pf-c-search-input"
+                    >
+                      <div
+                        class="pf-c-input-group"
+                      >
+                        <div
+                          class="pf-c-search-input__bar"
+                        >
+                          <span
+                            class="pf-c-search-input__text"
+                          >
+                            <span
+                              class="pf-c-search-input__icon"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                />
+                              </svg>
+                            </span>
+                            <input
+                              aria-label="Search input"
+                              class="pf-c-search-input__text-input"
+                              placeholder="Filter by name, version or UUID"
+                              value=""
+                            />
+                          </span>
+                          
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
                     class="pf-l-split__item"
                   >
                     <button
@@ -1890,14 +1981,14 @@ exports[`Satellite Manifest Panel renders loading when refetching data 1`] = `
                     class="pf-c-pagination__total-items"
                   >
                     <b>
-                      0
+                      1
                        - 
-                      0
+                      1
                     </b>
                      
                     of 
                     <b>
-                      0
+                      1
                     </b>
                      
                     
@@ -1914,14 +2005,14 @@ exports[`Satellite Manifest Panel renders loading when refetching data 1`] = `
                         class="pf-c-options-menu__toggle-text"
                       >
                         <b>
-                          0
+                          1
                            - 
-                          0
+                          1
                         </b>
                          
                         of 
                         <b>
-                          0
+                          1
                         </b>
                          
                         
@@ -2026,16 +2117,16 @@ exports[`Satellite Manifest Panel renders loading when refetching data 1`] = `
                         aria-label="Current page"
                         class="pf-c-form-control"
                         disabled=""
-                        max="0"
+                        max="1"
                         min="1"
                         type="number"
-                        value="0"
+                        value="1"
                       />
                       <span
                         aria-hidden="true"
                       >
                         of 
-                        0
+                        1
                       </span>
                     </div>
                     <div
@@ -2343,14 +2434,14 @@ exports[`Satellite Manifest Panel renders loading when refetching data 1`] = `
                     class="pf-c-options-menu__toggle-text"
                   >
                     <b>
-                      0
+                      1
                        - 
-                      0
+                      1
                     </b>
                      
                     of 
                     <b>
-                      0
+                      1
                     </b>
                      
                     
@@ -2455,16 +2546,16 @@ exports[`Satellite Manifest Panel renders loading when refetching data 1`] = `
                     aria-label="Current page"
                     class="pf-c-form-control"
                     disabled=""
-                    max="0"
+                    max="1"
                     min="1"
                     type="number"
-                    value="0"
+                    value="1"
                   />
                   <span
                     aria-hidden="true"
                   >
                     of 
-                    0
+                    1
                   </span>
                 </div>
                 <div
@@ -2604,7 +2695,7 @@ exports[`Satellite Manifest Panel renders loading when refetching data 1`] = `
 </div>
 `;
 
-exports[`Satellite Manifest Panel renders no results when there are no results 1`] = `
+exports[`Satellite Manifest Panel renders no results when there are no results and user is not admin 1`] = `
 <div>
   <section
     class="pf-c-page__main-section pf-m-light"
@@ -2641,22 +2732,7 @@ exports[`Satellite Manifest Panel renders no results when there are no results 1
               >
                 <div
                   class="pf-l-split pf-m-gutter"
-                >
-                  <div
-                    class="pf-l-split__item"
-                  >
-                    <button
-                      aria-disabled="false"
-                      class="pf-c-button pf-m-primary"
-                      data-ouia-component-id="OUIA-Generated-Button-primary-3"
-                      data-ouia-component-type="PF4/Button"
-                      data-ouia-safe="true"
-                      type="button"
-                    >
-                      Create new manifest
-                    </button>
-                  </div>
-                </div>
+                />
               </div>
               <div
                 class="pf-m-align-right"

--- a/src/pages/SatelliteManifestPage/SatelliteManifestPage.tsx
+++ b/src/pages/SatelliteManifestPage/SatelliteManifestPage.tsx
@@ -6,7 +6,6 @@ import { PageHeaderTitle } from '@redhat-cloud-services/frontend-components/Page
 import SatelliteManifestPanel from '../../components/SatelliteManifestPanel';
 import useSatelliteManifests from '../../hooks/useSatelliteManifests';
 import Unavailable from '@redhat-cloud-services/frontend-components/Unavailable';
-import { CreateManifestPanel } from '../../components/emptyState';
 import { Processing } from '../../components/emptyState';
 import { useQueryClient } from 'react-query';
 import { User } from '../../hooks/useUser';
@@ -27,15 +26,7 @@ const SatelliteManifestPage: FC = () => {
         <>
           {isLoading && !error && <Processing />}
 
-          {!isLoading && !error && data?.length > 0 && (
-            <SatelliteManifestPanel data={data} user={user} isFetching={isFetching} />
-          )}
-
-          {!isLoading && !error && data?.length === 0 && user.isOrgAdmin === true && (
-            <CreateManifestPanel />
-          )}
-
-          {!isLoading && !error && data?.length === 0 && user.isOrgAdmin === false && (
+          {!isLoading && !error && (
             <SatelliteManifestPanel data={data} user={user} isFetching={isFetching} />
           )}
 


### PR DESCRIPTION
When deleting the final notification, the success toast notification was not being rendered because the entire manifest panel was being replaced by a blank state before the notification could be created.  This moves the blank state into the same component as the delete modal to prevent that.