### PR TITLE
Bugfix: Error message not properly displayed if create manifest hook does not get 200 back

### DIFF
--- a/src/components/CreateManifestModal/CreateManifestModal.tsx
+++ b/src/components/CreateManifestModal/CreateManifestModal.tsx
@@ -22,6 +22,7 @@ const CreateManifestModal: FC<CreateManifestModalProps> = ({ handleModalToggle, 
     mutate,
     isLoading: isCreatingManifest,
     isSuccess,
+    isError: errorCreatingManifest,
     reset: resetCreateSatelliteManifestQuery
   } = useCreateSatelliteManifest();
 
@@ -40,7 +41,6 @@ const CreateManifestModal: FC<CreateManifestModalProps> = ({ handleModalToggle, 
    */
 
   const hasCreatedManifest = typeof createManifestResponseData !== 'undefined';
-  const errorCreatingManifest = isSuccess && !hasCreatedManifest;
 
   const formHasError = errorCreatingManifest || hasSatelliteVersionsError;
 


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/TEAMNADO-2457

After a refactor, it appears there was a minor regression, where, if the create manifest hook is "successful" but with a non-200 response, the Create Manifest Modal form will reset back to the empty form, rather than show the error toast notification. This fixes that issue.

Steps to reproduce current bug: 

1. Go to the app
2. In the useCreateSatelliteManifests hook, change the conditional check for response.status to be something other than 200, say, 2000, just to simulate the error being thrown.
3. With the current branch you will see the form reset. With this branch, the form will properly close the modal and display the toast notification.