### PR TITLE
Update url-parse to 1.5.3 from 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11550,7 +11550,8 @@
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.2",
@@ -12302,7 +12303,8 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
     },
     "resolve": {
       "version": "1.20.0",
@@ -14952,6 +14954,7 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
       "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
+      "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11550,8 +11550,7 @@
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "queue-microtask": {
       "version": "1.2.2",
@@ -12303,8 +12302,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.20.0",
@@ -14951,10 +14949,9 @@
       "dev": true
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
-      "dev": true,
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "redux-promise-middleware": "6.1.2",
     "ts-loader": "^8.0.7",
     "typescript": "^4.0.5",
-    "url-parse": "^1.5.3",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -148,6 +147,7 @@
     "stylelint": "13.9.0",
     "stylelint-config-recommended-scss": "4.2.0",
     "stylelint-scss": "3.18.0",
+    "url-parse": "^1.5.3",
     "webpack": "5.24.4",
     "webpack-bundle-analyzer": "4.4.0",
     "webpack-cli": "4.5.0"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "redux-promise-middleware": "6.1.2",
     "ts-loader": "^8.0.7",
     "typescript": "^4.0.5",
+    "url-parse": "^1.5.3",
     "uuid": "^8.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This updates url-parse to version 1.5.3 to resolve a [security vulnerability](https://issues.redhat.com/browse/TEAMNADO-2696) found in versions below that.