### PR TITLE
update docs urls to 2023

### DIFF
--- a/src/components/SCAInfoIconWithPopover/SCAInfoIconWithPopover.tsx
+++ b/src/components/SCAInfoIconWithPopover/SCAInfoIconWithPopover.tsx
@@ -6,9 +6,8 @@ import './SCAInfoIconWithPopover.scss';
 
 const SCAInfoIconWithPopover: FunctionComponent = () => {
   const scaMoreInfoLink =
-    'https://access.redhat.com/documentation/en-us/subscription_central/2020-10/html/' +
-    'getting_started_with_subscription_watch_with_simple_content_access/assembly-activating-simplecontent' +
-    '#con-what-is-simplecontent_assembly-simplecontent-ctxt';
+    'https://access.redhat.com/documentation/en-us/subscription_central/2023/html/' +
+    'getting_started_with_simple_content_access/con-what-is-simplecontent_assembly-simplecontent-ctxt';
 
   return (
     <>

--- a/src/pages/SatelliteManifestPage/SatelliteManifestPage.tsx
+++ b/src/pages/SatelliteManifestPage/SatelliteManifestPage.tsx
@@ -16,7 +16,7 @@ const SatelliteManifestPage: FC = () => {
   const queryClient = useQueryClient();
   const user: User = queryClient.getQueryData('user');
   const manifestsMoreInfoLink =
-    'https://access.redhat.com/documentation/en-us/subscription_central/2021/html/' +
+    'https://access.redhat.com/documentation/en-us/subscription_central/2023/html/' +
     'creating_and_managing_manifests_for_a_connected_satellite_server/index';
 
   return (


### PR DESCRIPTION
Where links to Insights, Console, Cost & Subscriptions docs exist, this PR updates the url to the 2023 version

