### PR TITLE
Adjust basename by checking if insights is in href

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -7,7 +7,9 @@ import { getBaseName } from '@redhat-cloud-services/frontend-components-utilitie
 
 const AppEntry = ({ logger }) => (
   <Provider store={(logger ? init(logger) : init()).getStore()}>
-    <Router basename={`${getBaseName(window.location.pathname, 3)}`}>
+    <Router
+      basename={`${getBaseName(window.location.pathname, 2 + location.href.includes('insights'))}`}
+    >
       <App />
     </Router>
   </Provider>

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -8,7 +8,10 @@ import { getBaseName } from '@redhat-cloud-services/frontend-components-utilitie
 const AppEntry = ({ logger }) => (
   <Provider store={(logger ? init(logger) : init()).getStore()}>
     <Router
-      basename={`${getBaseName(window.location.pathname, 2 + location.href.includes('insights'))}`}
+      basename={`${getBaseName(
+        window.location.pathname,
+        location.href.includes('insights') ? 3 : 2
+      )}`}
     >
       <App />
     </Router>


### PR DESCRIPTION
### Description

Since Subscriptions manifest can be now in two places we have to adjust the basename to properly be set if in insights bundle we're going to remove 3 items from the pathname, however if in subs bundle we'll remove just 2 items.