### PR TITLE
Teamnado 5960: Add manifest creation gate via chrome.auth.user.entitlements

### DIFF
--- a/src/components/CreateManifestButtonWithModal/CreateManifestButtonWithModal.tsx
+++ b/src/components/CreateManifestButtonWithModal/CreateManifestButtonWithModal.tsx
@@ -2,6 +2,7 @@ import React, { FC, useState } from 'react';
 import { Button } from '@patternfly/react-core';
 import CreateManifestModal from '../CreateManifestModal';
 import { User } from '../../hooks/useUser';
+import { Tooltip } from '@patternfly/react-core';
 
 interface CreateManifestButtonWithModalProps {
   user: User;
@@ -14,11 +15,25 @@ const CreateManifestButtonWithModal: FC<CreateManifestButtonWithModalProps> = ({
     setIsModalOpen(!isModalOpen);
   };
 
+  const createButton = (
+    <Button
+      variant="primary"
+      onClick={handleModalToggle}
+      isDisabled={!user.canWriteManifests || !user.isEntitled}
+    >
+      Create new manifest
+    </Button>
+  );
+
   return (
     <>
-      <Button variant="primary" onClick={handleModalToggle} isDisabled={!user.canWriteManifests}>
-        Create new manifest
-      </Button>
+      {user.isEntitled ? (
+        createButton
+      ) : (
+        <Tooltip content="Your account has no Satellite subscriptions" trigger="mouseenter">
+          <div>{createButton}</div>
+        </Tooltip>
+      )}
       <CreateManifestModal handleModalToggle={handleModalToggle} isModalOpen={isModalOpen} />
     </>
   );

--- a/src/components/CreateManifestButtonWithModal/__tests__/CreateManifestButtonWithModal.test.tsx
+++ b/src/components/CreateManifestButtonWithModal/__tests__/CreateManifestButtonWithModal.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import CreateManifestButtonWithModal from '..';
 import useSatelliteVersions, { SatelliteVersion } from '../../../hooks/useSatelliteVersions';
 import { QueryClientProvider, QueryClient } from 'react-query';
 import factories from '../../../utilities/factories';
-import { createQueryWrapper } from '../../../utilities/testHelpers';
 import '@testing-library/jest-dom/extend-expect';
+import useUser from '../../../hooks/useUser';
 
 jest.mock('../../../hooks/useUser');
 jest.mock('../../../hooks/useSatelliteVersions');
@@ -38,6 +38,17 @@ it('renders the Create manifest form with disabled button for user', async () =>
     isLoading: false,
     data: []
   });
+  const { getByText } = render(
+    <QueryClientProvider client={queryClient}>
+      <CreateManifestButtonWithModal user={factories.user.build({ canWriteManifests: false })} />
+    </QueryClientProvider>
+  );
+
+  expect(getByText('Create new manifest').closest('button')).toHaveAttribute('disabled');
+});
+
+it('renders the create button disabled', () => {
+  (useUser as jest.Mock).mockReturnValue(factories.user.build({ isEntitled: false }));
   const { getByText } = render(
     <QueryClientProvider client={queryClient}>
       <CreateManifestButtonWithModal user={factories.user.build({ canWriteManifests: false })} />

--- a/src/components/NoSatelliteSubs/NoSatelliteSubs.tsx
+++ b/src/components/NoSatelliteSubs/NoSatelliteSubs.tsx
@@ -14,7 +14,7 @@ export const NoSatelliteSubs = () => {
     <EmptyState variant={EmptyStateVariant.large}>
       <EmptyStateIcon icon={WrenchIcon} />
       <Title headingLevel="h2" size="lg">
-        You account has no Satellite subscriptions
+        Your account has no Satellite subscriptions
       </Title>
       <EmptyStateBody>
         <TextContent className="pf-u-mb-xl">

--- a/src/components/NoSatelliteSubs/NoSatelliteSubs.tsx
+++ b/src/components/NoSatelliteSubs/NoSatelliteSubs.tsx
@@ -1,0 +1,37 @@
+import { EmptyStateIcon } from '@patternfly/react-core';
+import { EmptyState } from '@patternfly/react-core';
+import React from 'react';
+import WrenchIcon from '@patternfly/react-icons/dist/js/icons/wrench-icon';
+import { Title } from '@patternfly/react-core';
+import { EmptyStateBody } from '@patternfly/react-core';
+import { Text, TextContent } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
+import { EmptyStateVariant } from '@patternfly/react-core';
+import { supportLink, subscriptionInventoryLink } from '../../utilities/consts';
+
+export const NoSatelliteSubs = () => {
+  return (
+    <EmptyState variant={EmptyStateVariant.large}>
+      <EmptyStateIcon icon={WrenchIcon} />
+      <Title headingLevel="h2" size="lg">
+        You account has no Satellite subscriptions
+      </Title>
+      <EmptyStateBody>
+        <TextContent className="pf-u-mb-xl">
+          <Text variant="small">
+            A Satellite subscription is required to create a manifest. Contact support to determine
+            if you need a new subscription. To view recently expired subscriptions, select the{' '}
+            <em>Expired</em> card in your subscription inventory.
+          </Text>
+        </TextContent>
+        <Button variant="primary" component="a" href={supportLink} target="_blank">
+          Contact support
+        </Button>
+        <br />
+        <Button variant="link" component="a" href={subscriptionInventoryLink}>
+          View subscription inventory
+        </Button>
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};

--- a/src/components/NoSatelliteSubs/__tests__/NoSatelliteSubs.test.tsx
+++ b/src/components/NoSatelliteSubs/__tests__/NoSatelliteSubs.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { supportLink, subscriptionInventoryLink } from '../../../utilities/consts';
+import { NoSatelliteSubs } from '../NoSatelliteSubs';
+
+it('shows the error message', () => {
+  const { getByText } = render(<NoSatelliteSubs />);
+  expect(getByText('Your account has no Satellite subscriptions')).toBeInTheDocument();
+});
+
+it('links to support', () => {
+  const { getByText } = render(<NoSatelliteSubs />);
+  expect(getByText('Contact support')).toHaveAttribute('href', supportLink);
+});
+
+it('links to subscription inventory', () => {
+  const { getByText } = render(<NoSatelliteSubs />);
+  expect(getByText('View subscription inventory')).toHaveAttribute(
+    'href',
+    subscriptionInventoryLink
+  );
+});

--- a/src/components/NoSatelliteSubs/index.tsx
+++ b/src/components/NoSatelliteSubs/index.tsx
@@ -1,0 +1,3 @@
+import { NoSatelliteSubs } from './NoSatelliteSubs';
+
+export { NoSatelliteSubs };

--- a/src/hooks/__tests__/useUser.test.tsx
+++ b/src/hooks/__tests__/useUser.test.tsx
@@ -24,6 +24,9 @@ describe('useUser hook', () => {
         user: {
           is_org_admin: true
         }
+      },
+      entitlements: {
+        smart_management: { is_entitled: true }
       }
     });
 
@@ -51,6 +54,7 @@ describe('useUser hook', () => {
     expect(result.current.data).toEqual({
       canReadManifests: true,
       canWriteManifests: true,
+      isEntitled: true,
       isOrgAdmin: true,
       isSCACapable: true
     });

--- a/src/hooks/__tests__/useUser.test.tsx
+++ b/src/hooks/__tests__/useUser.test.tsx
@@ -3,7 +3,6 @@ import fetch, { enableFetchMocks } from 'jest-fetch-mock';
 import { useAuthenticateUser, useUserRbacPermissions } from '../../utilities/platformServices';
 import useUser from '../useUser';
 import { createQueryWrapper } from '../../utilities/testHelpers';
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 enableFetchMocks();
 

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -8,6 +8,7 @@ import {
 interface User {
   canReadManifests: boolean;
   canWriteManifests: boolean;
+  isEntitled: boolean;
   isOrgAdmin: boolean;
   isSCACapable: boolean;
 }
@@ -43,6 +44,7 @@ const useUser = () => {
       canWriteManifests:
         rbacPermissions.includes('subscriptions:manifests:write') ||
         rbacPermissions.includes('subscriptions:*:*'),
+      isEntitled: userStatus.entitlements.smart_management?.is_entitled,
       isOrgAdmin: userStatus.identity.user.is_org_admin === true,
       isSCACapable: scaStatusResponse.body.simpleContentAccessCapable === true
     };

--- a/src/pages/SatelliteManifestPage/SatelliteManifestPage.tsx
+++ b/src/pages/SatelliteManifestPage/SatelliteManifestPage.tsx
@@ -6,15 +6,16 @@ import SatelliteManifestPanel from '../../components/SatelliteManifestPanel';
 import useSatelliteManifests from '../../hooks/useSatelliteManifests';
 import Unavailable from '@redhat-cloud-services/frontend-components/Unavailable';
 import { Processing } from '../../components/emptyState';
-import { useQueryClient } from 'react-query';
-import { User } from '../../hooks/useUser';
+import useUser from '../../hooks/useUser';
 import ExternalLink from '../../components/ExternalLink';
+import { NoSatelliteSubs } from '../../components/NoSatelliteSubs';
+import { Alert } from '@patternfly/react-core';
+import { subscriptionInventoryLink, supportLink } from '../../utilities/consts';
 
 const SatelliteManifestPage: FC = () => {
   const { isLoading, isFetching, error, data } = useSatelliteManifests();
 
-  const queryClient = useQueryClient();
-  const user: User = queryClient.getQueryData('user');
+  const { data: user } = useUser();
   const manifestsMoreInfoLink =
     'https://access.redhat.com/documentation/en-us/subscription_central/2023/html/' +
     'creating_and_managing_manifests_for_a_connected_satellite_server/index';
@@ -31,6 +32,18 @@ const SatelliteManifestPage: FC = () => {
             <ExternalLink href={manifestsMoreInfoLink}>
               Learn more about creating and managing manifests for a connected Satellite Server
             </ExternalLink>
+            {!user.isEntitled && !isLoading && data?.length != 0 && (
+              <Alert title="Your account has no Satellite subscriptions" isInline variant="info">
+                You can view existing manifests for your account, however, an active Satellite
+                subscription is required to create a new manifest.{' '}
+                <a href={supportLink} target="_blank" rel="noreferrer">
+                  Contact support
+                </a>{' '}
+                to determine if you need a new subscription. To view recently expired subscriptions,
+                select the <em>Expired</em> card in your{' '}
+                <a href={subscriptionInventoryLink}>subscription inventory</a>.
+              </Alert>
+            )}
           </Text>
         </TextContent>
       </PageHeader>
@@ -38,7 +51,9 @@ const SatelliteManifestPage: FC = () => {
         <>
           {isLoading && !error && <Processing />}
 
-          {!isLoading && !error && (
+          {!isLoading && !error && !user.isEntitled && data.length == 0 && <NoSatelliteSubs />}
+
+          {!isLoading && !error && (user.isEntitled || data.length != 0) && (
             <SatelliteManifestPanel data={data} user={user} isFetching={isFetching} />
           )}
 

--- a/src/pages/SatelliteManifestPage/__tests__/SatelliteManifestPage.test.tsx
+++ b/src/pages/SatelliteManifestPage/__tests__/SatelliteManifestPage.test.tsx
@@ -13,6 +13,7 @@ import factories from '../../../utilities/factories';
 import { get, def } from 'bdd-lazy-var';
 import '@testing-library/jest-dom/extend-expect';
 import '@testing-library/jest-dom';
+import { subscriptionInventoryLink, supportLink } from '../../../utilities/consts';
 
 jest.mock('../../../hooks/useSatelliteManifests');
 jest.mock('../../../hooks/useUser');
@@ -150,5 +151,70 @@ describe('when the user call fails', () => {
 
     const { getByText } = render(<SatellitePage />);
     expect(getByText('This page is temporarily unavailable')).toBeInTheDocument();
+  });
+});
+
+describe('when the user is not entitled', () => {
+  beforeEach(() => {
+    (useUser as jest.Mock).mockReturnValue({
+      isLoading: false,
+      isFetching: false,
+      isSuccess: true,
+      isError: false,
+      data: factories.user.build({ isEntitled: false })
+    });
+  });
+
+  it('shows the empty state when they also have no manifests', () => {
+    (useSatelliteManifests as jest.Mock).mockReturnValue({
+      isLoading: false,
+      error: false,
+      data: []
+    });
+
+    const { container } = render(<SatellitePage />);
+    expect(container.querySelector('.pf-c-empty-state__content > .pf-c-title').textContent).toEqual(
+      'Your account has no Satellite subscriptions'
+    );
+  });
+
+  describe('and has manifests already', () => {
+    beforeEach(() => {
+      (useSatelliteManifests as jest.Mock).mockReturnValue({
+        isLoading: false,
+        data: [
+          {
+            name: 'Sputnik',
+            type: 'Satellite',
+            url: 'www.example.com',
+            uuid: '00000000-0000-0000-0000-000000000000',
+            version: '1.2.3'
+          }
+        ]
+      });
+    });
+
+    it('shows the list', () => {
+      const { getByText } = render(<SatellitePage />);
+      expect(getByText('Sputnik')).toBeInTheDocument();
+    });
+
+    it('shows the notification', () => {
+      const { getByText } = render(<SatellitePage />);
+      expect(getByText('Your account has no Satellite subscriptions')).toBeInTheDocument();
+    });
+
+    it('links to support', () => {
+      const { getByText } = render(<SatellitePage />);
+      expect(getByText('Contact support')).toHaveAttribute('href', supportLink);
+    });
+
+    it('links to subscription inventory', () => {
+      const { getByText } = render(<SatellitePage />);
+      expect(getByText('subscription inventory')).toHaveAttribute(
+        'href',
+        subscriptionInventoryLink
+      );
+    });
   });
 });

--- a/src/utilities/consts.ts
+++ b/src/utilities/consts.ts
@@ -1,0 +1,3 @@
+export const supportLink = 'https://access.redhat.com/support';
+
+export const subscriptionInventoryLink = window.location.pathname.replace('manifests', 'inventory');

--- a/src/utilities/factories/user.ts
+++ b/src/utilities/factories/user.ts
@@ -5,5 +5,6 @@ export default Factory.define<User>(() => ({
   canReadManifests: true,
   canWriteManifests: true,
   isOrgAdmin: true,
-  isSCACapable: true
+  isSCACapable: true,
+  isEntitled: true
 }));


### PR DESCRIPTION
This adds a gate for manifest creation based on whether or not the user
has a satellite subscription. This is checked via whether or not the
user is entitled to smart_management.

When the user is entitled, the application functions the same as it has
previously. In the case that the user is _not entitled_, yet has
manifests, they should still be able to manage preexisting, but not
create new, manifests. In the case the user is _not entitled_ and has
_no manifests_ they should receive a friendly empty state that directs
them to support, and their subscriptions.