### PR TITLE
TEAMNADO-6479: Remove nested `BrowserRouter`

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -25,7 +25,12 @@ plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')({
     root: resolve(__dirname, '../'),
     moduleName: 'manifests',
-    useFileHash: false
+    useFileHash: false,
+    shared: [
+      {
+        'react-router-dom': { singleton: true, requiredVersion: '*' }
+      }
+    ]
   })
 );
 

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -12,7 +12,12 @@ const { config: webpackConfig, plugins } = config({
 plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')({
     root: resolve(__dirname, '../'),
-    moduleName: 'manifests'
+    moduleName: 'manifests',
+    shared: [
+      {
+        'react-router-dom': { singleton: true, requiredVersion: '*' }
+      }
+    ]
   })
 );
 

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -1,20 +1,11 @@
 import React from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { init } from './store';
 import App from './App';
-import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 
 const AppEntry = ({ logger }) => (
   <Provider store={(logger ? init(logger) : init()).getStore()}>
-    <Router
-      basename={`${getBaseName(
-        window.location.pathname,
-        location.href.includes('insights') ? 3 : 2
-      )}`}
-    >
-      <App />
-    </Router>
+    <App />
   </Provider>
 );
 


### PR DESCRIPTION
This removes the nested `BrowserRouter` to support the platform's upgrade to React Router v6