### PR TITLE
TEAMNADO-6259: Replace "subscription allocation" with "manifest"

### DIFF
--- a/src/components/ManifestDetailSidePanel/ManifestDetailSidePanel.tsx
+++ b/src/components/ManifestDetailSidePanel/ManifestDetailSidePanel.tsx
@@ -94,8 +94,8 @@ const ManifestDetailSidePanel: FC<ManifestDetailSidePanelProps> = ({
     return (
       <>
         <p className="sub-manifest-details-delete-text">
-          Deleting a subscription allocation is <strong>STRONGLY</strong> discouraged. This action
-          should only be taken in extreme circumstances or for debugging purposes
+          Deleting a manifest is <strong>STRONGLY</strong> discouraged. This action should only be
+          taken in extreme circumstances or for debugging purposes
         </p>
         <Button
           variant="tertiary"

--- a/src/components/ManifestEntitlementsList/ManifestEntitlementsList.tsx
+++ b/src/components/ManifestEntitlementsList/ManifestEntitlementsList.tsx
@@ -94,7 +94,7 @@ const ManifestEntitlementsList: FC<ManifestEntitlementsListProps> = ({
       {isSuccess && entitlementsData.valid && (
         <Table
           ref={entitlementsRowRef}
-          aria-label="Allocations table"
+          aria-label="Manifests table"
           variant="compact"
           borders={false}
           isNested={true}

--- a/src/components/ManifestEntitlementsList/__tests__/ManifestEntitlementsList.test.tsx
+++ b/src/components/ManifestEntitlementsList/__tests__/ManifestEntitlementsList.test.tsx
@@ -51,7 +51,7 @@ describe('Manifest Entitlements List', () => {
     const { getByLabelText } = render(<ManifestEntitlementsList {...props} />);
 
     expect(
-      getByLabelText('Allocations table').children[1].firstChild.childNodes[1].textContent
+      getByLabelText('Manifests table').children[1].firstChild.childNodes[1].textContent
     ).toEqual(entitlementsData.value[0].sku);
   });
 
@@ -92,7 +92,7 @@ describe('Manifest Entitlements List', () => {
   it('renders correctly when no entitlements are attached to the manifest', () => {
     mockResponse({
       valid: false,
-      reason: 'No Entitlements are attached to the Allocation'
+      reason: 'No Entitlements are attached to the manifest'
     });
     const props = {
       entitlementsRowRef: null as React.MutableRefObject<HTMLSpanElement>,
@@ -100,7 +100,7 @@ describe('Manifest Entitlements List', () => {
     };
     const { queryByLabelText } = render(<ManifestEntitlementsList {...props} />);
 
-    expect(queryByLabelText('Allocations table')).toBeNull();
+    expect(queryByLabelText('Manifests table')).toBeNull();
   });
 
   it('renders with an error message when the API call fails', () => {
@@ -110,7 +110,7 @@ describe('Manifest Entitlements List', () => {
       isError: false,
       entitlementsData: {
         valid: false,
-        reason: 'No Entitlements are attached to the Allocation'
+        reason: 'No Entitlements are attached to the manifest'
       },
       entitlementsRowRef: null as React.MutableRefObject<HTMLSpanElement>,
       uuid: 'abc123'
@@ -125,7 +125,7 @@ describe('Manifest Entitlements List', () => {
     mockResponse(
       {
         valid: false,
-        reason: 'No Allocations found'
+        reason: 'No Manifests found'
       },
       true
     );

--- a/src/components/SCAInfoIconWithPopover/SCAInfoIconWithPopover.tsx
+++ b/src/components/SCAInfoIconWithPopover/SCAInfoIconWithPopover.tsx
@@ -23,8 +23,7 @@ const SCAInfoIconWithPopover: FunctionComponent = () => {
         }
         footerContent={
           <ExternalLink href={scaMoreInfoLink}>
-            Learn more about enabling simple content access on an existing Satellite allocation and
-            manifest
+            Learn more about enabling simple content access on an existing manifest
           </ExternalLink>
         }
       >


### PR DESCRIPTION
This changes all instances of subscription allocation to manifest in the content of the page. This does not change references to allocations in function or variable names.