### PR TITLE
TUSC-84: Render NoAccessPage in current route

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -5,7 +5,6 @@ import Authentication from './components/Authentication';
 
 const SatelliteManifestPage = lazy(() => import('./pages/SatelliteManifestPage'));
 const OopsPage = lazy(() => import('./pages/OopsPage'));
-const NoPermissionsPage = lazy(() => import('./pages/NoPermissionsPage'));
 
 export const ManifestRoutes: ReactNode = () => (
   <div className="manifests">
@@ -14,7 +13,6 @@ export const ManifestRoutes: ReactNode = () => (
         <Routes>
           <Route path="/" element={<SatelliteManifestPage />} />
           <Route path="/oops" element={<OopsPage />} />
-          <Route path="/no-permissions" element={<NoPermissionsPage />} />
           {/* Finally, catch all unmatched routes */}
           <Route path="*" element={<Navigate to="/oops" replace />} />
         </Routes>

--- a/src/pages/SatelliteManifestPage/SatelliteManifestPage.tsx
+++ b/src/pages/SatelliteManifestPage/SatelliteManifestPage.tsx
@@ -11,11 +11,10 @@ import { NoSatelliteSubs } from '../../components/NoSatelliteSubs';
 import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
 import { subscriptionInventoryLink, supportLink } from '../../utilities/consts';
 import { PageSection } from '@patternfly/react-core/dist/dynamic/components/Page';
-import { useNavigate } from 'react-router-dom';
+import NoPermissionsPage from '../NoPermissionsPage';
 
 const SatelliteManifestPage: FC = () => {
   const { isLoading, isFetching, error, data } = useSatelliteManifests();
-  const navigate = useNavigate();
 
   const { data: user, isError: userError } = useUser();
   const manifestsMoreInfoLink =
@@ -23,7 +22,7 @@ const SatelliteManifestPage: FC = () => {
     'creating_and_managing_manifests_for_a_connected_satellite_server/index';
 
   if (!user.canReadManifests) {
-    navigate('./no-permissions');
+    return <NoPermissionsPage />;
   }
 
   const hasError = error || userError;

--- a/src/pages/SatelliteManifestPage/__tests__/SatelliteManifestPage.test.tsx
+++ b/src/pages/SatelliteManifestPage/__tests__/SatelliteManifestPage.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable prettier/prettier */
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import SatelliteManifestPage from '../SatelliteManifestPage';
 import Authentication from '../../../components/Authentication';
 import { BrowserRouter as Router } from 'react-router-dom';
@@ -216,4 +216,25 @@ describe('when the user is not entitled', () => {
       );
     });
   });
+});
+
+it('Renders no access when the user is not entitled', () => {
+  (useUser as jest.Mock).mockReturnValue({
+    isLoading: false,
+    isFetching: false,
+    isSuccess: true,
+    isError: false,
+    data: { canReadManifests: false }
+  });
+
+  (useSatelliteManifests as jest.Mock).mockReturnValueOnce({
+    isLoading: false,
+    data: [],
+    error: false,
+    isError: false
+  });
+
+  render(<SatellitePage />);
+
+  expect(screen.getByText('You do not have access to Manifests')).toBeInTheDocument();
 });


### PR DESCRIPTION
Instead of redirecting to /no-access, just render that page in route so that back button functionality works as expected

## Summary by Sourcery

Render the no-access page directly in the current route to preserve back button functionality and clean up the unused /no-permissions route

Enhancements:
- Render NoPermissionsPage inline within the SatelliteManifestPage instead of navigating to a separate route
- Remove the deprecated /no-permissions route and its lazy import from the main routes configuration

Tests:
- Add a test to verify the no-access message appears when the user lacks manifest read permissions