### PR TITLE
TUSC-582: Use api call directly

### DIFF
--- a/src/hooks/__tests__/useHasRelation.test.tsx
+++ b/src/hooks/__tests__/useHasRelation.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import {
-  fetchDefaultWorkspace,
+  // fetchDefaultWorkspace, TODO: Add back once the sdk is fixed
   useAccessCheckContext
 } from '@project-kessel/react-kessel-access-check';
 import { checkSelf } from '@project-kessel/react-kessel-access-check/core/api-client';
@@ -10,6 +10,17 @@ import { createQueryWrapper } from '../../utilities/testHelpers';
 
 jest.mock('@project-kessel/react-kessel-access-check');
 jest.mock('@project-kessel/react-kessel-access-check/core/api-client');
+
+// ------------------------------------------------------------
+// TODO: remove once sdk is used for default workspace fetching
+// ------------------------------------------------------------
+
+import { fetchDefaultWorkspace } from '../../utilities/fetchDefaultWorkspace';
+jest.mock('../../utilities/fetchDefaultWorkspace');
+
+// ------------------------------------------------------------
+// TODO: End remove block
+// ------------------------------------------------------------
 
 describe('useHasRelation hook', () => {
   const mockCheckSelf = checkSelf as jest.Mock;

--- a/src/hooks/useHasRelation.ts
+++ b/src/hooks/useHasRelation.ts
@@ -1,9 +1,10 @@
 import {
-  fetchDefaultWorkspace,
+  // fetchDefaultWorkspace, TODO: Add back once the sdk is fixed
   useAccessCheckContext
 } from '@project-kessel/react-kessel-access-check';
 import { checkSelf } from '@project-kessel/react-kessel-access-check/core/api-client';
 import { useQuery } from '@tanstack/react-query';
+import { fetchDefaultWorkspace } from '../utilities/fetchDefaultWorkspace'; // TODO remove once sdk is fixed
 
 const QUERY_STALE_TIME = 5 * 60 * 1000;
 

--- a/src/utilities/fetchDefaultWorkspace.ts
+++ b/src/utilities/fetchDefaultWorkspace.ts
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------
+// TODO: remove file once sdk is used for default workspace fetching
+// ------------------------------------------------------------
+
+interface Workspace {
+  id: string;
+}
+
+export const fetchDefaultWorkspace = async (rbacBaseEndpoint: string) => {
+  const url = `${rbacBaseEndpoint.replace(/\/+$/, '')}/api/rbac/v2/workspaces/?type=default&with_ancestry=true`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'Content-type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error('failed to fetch default workspace');
+  }
+
+  const data: { data: Workspace[] } = await response.json();
+
+  return data.data[0];
+};


### PR DESCRIPTION
This fixes an issue with the kessel sdk's implementation of default workspace fetching. Once it has been fixed, these changes (marked clearly with TODOs) can be removed.

## Summary by Sourcery

Temporarily bypass the Kessel SDK for default workspace retrieval by introducing a direct API-based helper and wiring it into the useHasRelation hook and its tests.

Enhancements:
- Add a utility for fetching the default workspace directly via the RBAC API as an interim replacement for the SDK implementation.

Tests:
- Update useHasRelation tests to mock and exercise the new default workspace fetch utility instead of the SDK-provided function.