### PR TITLE
TUSC-583: Add to service tiles

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -40,6 +40,14 @@ objects:
             module: './RootApp'
             routes:
               - pathname: /subscriptions/manifests
+      serviceTiles:
+        - id: manifests
+          section: subscriptions
+          group: subscriptions
+          title: Manifests
+          href: /subscriptions/manifests
+          description: Create, manage, and export subscription manifests for Red Hat Satellite.
+          icon: SubscriptionsIcon
 
 parameters:
   - name: ENV_NAME


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Expose the subscriptions manifests page as a service tile with metadata including title, description, and icon in the frontend configuration.